### PR TITLE
Fix lingering white number

### DIFF
--- a/webview/src/code.js
+++ b/webview/src/code.js
@@ -38,7 +38,7 @@ const setupLines = (node, config) => {
           this.parentNode.classList.remove("line-focus");
           this.parentNode.classList.remove("git-add");
           this.parentNode.classList.remove("git-remove");
-          lineNum.classList.remove('text-white')
+          lineNum.classList.remove('!text-white')
 
         } else {
           this.parentNode.classList.add("line-focus");


### PR DESCRIPTION
When cycling through highlighted lines, any line you clicked on kept the while line number as the extension attempted to remove the `text-white` class instead of the `!text-white` class.

Now, when clicking lines when you return to the unselected state, the line number is back to its original color.