### PR TITLE
Remove `firstRowIsWhiteSpace` - unused and breaks empty lines

### DIFF
--- a/webview/src/code.js
+++ b/webview/src/code.js
@@ -19,8 +19,6 @@ const setupLines = (node, config) => {
       
       // lineNumber click event
       lineNum.onclick = function (e) {
-        var firstRowIsWhiteSpace = this.nextSibling.firstChild.firstChild.innerText.trim() === "";
-
         if(this.parentNode.classList.contains("line-focus")) {
           
           this.parentNode.classList.remove("line-focus");


### PR DESCRIPTION
The result of this value isn't used but it often fails when clicking on empty lines, resulting in gaps of highlighted text when there are new lines present.

Removing this line fixes this issue and removes an unused variable.

These pictures show the result of all three of these pull requests, allowing for linear-gradients, fixing the issue with the white line number, and allowing blank lines to be selected.

### Before
![old](https://user-images.githubusercontent.com/454563/204738338-221907b9-7434-45d5-9683-a75e533dc157.png)

### After
![fixed](https://user-images.githubusercontent.com/454563/204738342-c4af0154-011a-467a-a2f9-b6df1098a39e.png)
