### PR TITLE
Prevent double save dialog boxes by throttling save click

### DIFF
--- a/webview/src/index.js
+++ b/webview/src/index.js
@@ -1,4 +1,4 @@
-import { $, $$, setVar } from './util.js';
+import { $, $$, setVar, throttle } from './util.js';
 import { pasteCode } from './code.js';
 import { takeSnap, cameraFlashAnimation } from './snap.js';
 
@@ -74,8 +74,8 @@ window.addEventListener('message', ({ data: { type, ...cfg } }) => {
       btnCopy.textContent = "Save As..."
     }
 
-    btnSave.addEventListener('click', actions[0])
-    btnCopy.addEventListener('click', actions[1])
+    btnSave.addEventListener('click', throttle(actions[0], 1000))
+    btnCopy.addEventListener('click', throttle(actions[1], 1000))
 
     if(!showLineNumbers) {
       document.getElementById('showLineNumBtn').children[0].children[0].classList.toggle('opacity-0');

--- a/webview/src/util.js
+++ b/webview/src/util.js
@@ -18,3 +18,13 @@ export const calcTextWidth = (text) => {
   div.remove();
   return width + 1 + 'px';
 };
+
+export const throttle = (func, limit) => {
+	let lastRan;
+	return (...args) => {
+		if (!lastRan || Date.now() - lastRan >= limit) {
+			func.apply(null, ...args);
+			lastRan = Date.now();
+		}
+	};
+};


### PR DESCRIPTION
As it takes about half a second for the save dialog box to appear on the first click (it happens more quickly on subsequent clicks). It's easy to click the save button twice and have a second save dialog box appear after you save the image.

This allows the first click through, and then discards further clicks for one second to prevent this from happening.

This doesn't slow any normal usage down since we allow the first click through with no delay but prevents annoyances.