### PR TITLE
Correct `showWindowControlsBtn` reference

### DIFF
--- a/webview/src/index.js
+++ b/webview/src/index.js
@@ -9,7 +9,7 @@ const btnSave = $('#save');
 const btnCopy = $('#secondMainBtn');
 
 const showLineNumBtn = $('#showLineNumBtn');
-const showWindowControls = $('#showWindowControls');
+const showWindowControlsBtn = $('#showWindowControlsBtn');
 const modeChangeBtn = $("#modeChangeBtn")
 
 let _toolMode;


### PR DESCRIPTION
An event listener was being added to `showWindowControlsBtn` on line 101, but the variable was undefined. 

Here we correct the definition of `showWindowControlsBtn` and update it to point to the correct `id`.