### PR TITLE
Trim Empty Start/End Lines

### DIFF
--- a/webview/src/code.js
+++ b/webview/src/code.js
@@ -133,8 +133,9 @@ const setupLines = (node, config) => {
 
 const stripInitialIndent = (node) => {
   const regIndent = /^\s+/u;
-  const initialSpans = $$(':scope > div > span:first-child', node);
+  let initialSpans = $$(':scope > div > span:first-child', node);
   if (initialSpans.some((span) => !regIndent.test(span.textContent))) return;
+  initialSpans = initialSpans.filter((span) => span.textContent.trim() === "");
   const minIndent = Math.min(
     ...initialSpans.map((span) => span.textContent.match(regIndent)[0].length)
   );

--- a/webview/src/code.js
+++ b/webview/src/code.js
@@ -19,8 +19,6 @@ const setupLines = (node, config) => {
       
       // lineNumber click event
       lineNum.onclick = function (e) {
-        var firstRowIsWhiteSpace = this.nextSibling.firstChild.firstChild.innerText.trim() === "";
-
         if(this.parentNode.classList.contains("line-focus")) {
           
           this.parentNode.classList.remove("line-focus");


### PR DESCRIPTION
It's quite easy to select the end of a line with no text, or an empty line at the start/end of the code you intend to screenshot.

This trims the resulting HTML of any blank lines at the start/end of the code, removing the need to reselect.

### With this selection:
![selection](https://user-images.githubusercontent.com/454563/204911656-98a12bc1-041c-4699-99fe-0d461fa18f89.png)

### Old behavior:
![old selection](https://user-images.githubusercontent.com/454563/204911690-9c93f013-6fe4-4cc1-8c48-e69be7945f5d.png)

### New Behavior: 
![new selection](https://user-images.githubusercontent.com/454563/204911706-3842f869-854b-4a4c-b0b9-cbb8722a74b1.png)
