### PR TITLE
Move UI setup to its own event

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -76,6 +76,8 @@ const hasOneSelection = (selections) =>
 const runCommand = async (context) => {
   const panel = await createPanel(context);
 
+  panel.webview.postMessage({ type: 'setup-ui', ...getConfig() });
+
   const update = async () => {
     await vscode.commands.executeCommand('editor.action.clipboardCopyWithSyntaxHighlightingAction');
     panel.webview.postMessage({ type: 'update', ...getConfig() });

--- a/webview/src/index.js
+++ b/webview/src/index.js
@@ -9,7 +9,7 @@ const btnSave = $('#save');
 const btnCopy = $('#secondMainBtn');
 
 const showLineNumBtn = $('#showLineNumBtn');
-const showWindowControls = $('#showWindowControls');
+const showWindowControlsBtn = $('#showWindowControlsBtn');
 const modeChangeBtn = $("#modeChangeBtn")
 
 let _toolMode;
@@ -23,7 +23,62 @@ document.addEventListener('copy', () => takeSnap({ ...config, shutterAction: 'co
 document.addEventListener('paste', (e) => pasteCode(config, e.clipboardData));
 
 window.addEventListener('message', ({ data: { type, ...cfg } }) => {
-  if (type === 'update') {
+  if (type === 'setup-ui') {
+    config = cfg;
+
+    const {
+      showWindowTitle,
+      shutterAction,
+      toolMode
+    } = config;
+
+    _toolMode = toolMode
+
+    let actions = []
+    if (shutterAction === "save") {
+      actions = [
+        () => takeSnap(config), 
+        () => takeSnap({ ...config, shutterAction: 'copy' }),
+      ]
+      btnCopy.textContent = "Copy"
+    } else {
+      actions = [
+        () => takeSnap(config),
+        () => takeSnap({ ...config, shutterAction: 'save' }), 
+      ]
+      btnCopy.textContent = "Save As..."
+    }
+
+    btnSave.addEventListener('click', actions[0])
+    btnCopy.addEventListener('click', actions[1])
+
+    showLineNumBtn.addEventListener('click', () => {
+      document.getElementById('showLineNumBtn').children[0].children[0].classList.toggle('opacity-0');
+
+      // showLineNumBtn.firstChild.classList.toggle('opacity-100');
+
+      const lineNums = $$('.line-number');
+    
+      lineNums.forEach(lineNum => {
+        lineNum.classList.toggle("hidden")
+      })
+    })
+
+
+    showWindowControlsBtn.addEventListener('click', () => {
+      document.getElementById('showWindowControlsBtn').children[0].children[0].classList.toggle('opacity-0');
+      windowControlsNode.hidden = !windowControlsNode.hidden
+      navbarNode.hidden = windowControlsNode.hidden && !showWindowTitle;
+    })
+
+    toolModeToggled()
+
+    modeChangeBtn.addEventListener('click', () => {
+      _toolMode = _toolMode==='advanced' ? 'simple': 'advanced'
+      toolModeToggled()
+    })
+  }
+  else if (type === 'update') {
     config = cfg;
 
     const {
@@ -36,7 +91,6 @@ window.addEventListener('message', ({ data: { type, ...cfg } }) => {
       showWindowControls,
       showWindowTitle,
       windowTitle,
-      shutterAction,
       showLineNumbers,
       toolMode
     } = config;
@@ -57,66 +111,22 @@ window.addEventListener('message', ({ data: { type, ...cfg } }) => {
 
     windowTitleNode.textContent = windowTitle;
 
+    if (!showLineNumbers) {
+      document.getElementById('showLineNumBtn').children[0].children[0].classList.toggle('opacity-0');
+    }
+
+    if (!showWindowControls){
+      document.getElementById('showWindowControlsBtn').children[0].children[0].classList.toggle('opacity-0');
+    }
+
     document.execCommand('paste');
-
-    let actions = []
-    if(shutterAction == "save") {
-      actions = [
-        () => takeSnap(config), 
-        () => takeSnap({ ...config, shutterAction: 'copy' }),
-      ]
-      btnCopy.textContent = "Copy"
-    } else {
-      actions = [
-        () => takeSnap(config),
-        () => takeSnap({ ...config, shutterAction: 'save' }), 
-      ]
-      btnCopy.textContent = "Save As..."
-    }
-
-    btnSave.addEventListener('click', actions[0])
-    btnCopy.addEventListener('click', actions[1])
-
-    if(!showLineNumbers) {
-      document.getElementById('showLineNumBtn').children[0].children[0].classList.toggle('opacity-0');
-    }
-
-    showLineNumBtn.addEventListener('click', () => {
-
-      document.getElementById('showLineNumBtn').children[0].children[0].classList.toggle('opacity-0');
-
-      // showLineNumBtn.firstChild.classList.toggle('opacity-100');
-
-      const lineNums = $$('.line-number');
-    
-      lineNums.forEach(lineNum => {
-        lineNum.classList.toggle("hidden")
-      })
-    })
-
-    if(!showWindowControls){
-      document.getElementById('showWindowControlsBtn').children[0].children[0].classList.toggle('opacity-0');
-    }
-    showWindowControlsBtn.addEventListener('click', () => {
-      document.getElementById('showWindowControlsBtn').children[0].children[0].classList.toggle('opacity-0');
-      windowControlsNode.hidden = !windowControlsNode.hidden
-      navbarNode.hidden = windowControlsNode.hidden && !showWindowTitle;
-    })
-
-    toolModeToggled()
-
-    modeChangeBtn.addEventListener('click', () => {
-      _toolMode = _toolMode==='advanced' ? 'simple': 'advanced'
-      toolModeToggled()
-    })
-
   } else if (type === 'flash') {
     cameraFlashAnimation();
   }
 });
 
 const toolModeToggled = () => {
-  if(_toolMode=='advanced') {
+  if(_toolMode === 'advanced') {
     btnCopy.classList.remove("hidden")
     $('#showLineNumBtn').classList.remove("hidden")
     $('#showWindowControlsBtn').classList.remove("hidden")


### PR DESCRIPTION
Right now every single time text is selected a new event handler is added to the Save/Copy buttons.

This results in a huge number of event handlers being added to the buttons. In my testing after a few selections a single click on Copy the shutter action would be triggered 40+ times.

Here we move the UI setup to its own event and only trigger paste during the update event.

### Before (single click after making multiple selections with CodeSnap-plus open)
![multiple times](https://user-images.githubusercontent.com/454563/204921606-06aea103-2e22-4b7d-ad2f-6233b26e0738.png)
### After (single click)
![single call](https://user-images.githubusercontent.com/454563/204921582-6f556a31-5083-47b5-8c68-84fad824aa14.png)
